### PR TITLE
Remove indirect-load for constants on Xtensa Target to improve performance

### DIFF
--- a/core/iwasm/compilation/aot_emit_const.c
+++ b/core/iwasm/compilation/aot_emit_const.c
@@ -12,6 +12,7 @@ aot_compile_op_i32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 {
     LLVMValueRef value;
 
+#if !defined(BUILD_TARGET_XTENSA)
     if (comp_ctx->is_indirect_mode
         && aot_intrinsic_check_capability(comp_ctx, "i32.const")) {
         WASMValue wasm_value;
@@ -22,7 +23,9 @@ aot_compile_op_i32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             return false;
         }
     }
-    else {
+    else 
+#endif
+    {
         value = I32_CONST((uint32)i32_const);
         CHECK_LLVM_CONST(value);
     }
@@ -40,6 +43,7 @@ aot_compile_op_i64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 {
     LLVMValueRef value;
 
+#if !defined(BUILD_TARGET_XTENSA)
     if (comp_ctx->is_indirect_mode
         && aot_intrinsic_check_capability(comp_ctx, "i64.const")) {
         WASMValue wasm_value;
@@ -50,7 +54,9 @@ aot_compile_op_i64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             return false;
         }
     }
-    else {
+    else 
+#endif
+    {
         value = I64_CONST((uint64)i64_const);
         CHECK_LLVM_CONST(value);
     }
@@ -69,6 +75,7 @@ aot_compile_op_f32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMValueRef alloca, value;
 
     if (!isnan(f32_const)) {
+#if !defined(BUILD_TARGET_XTENSA)
         if (comp_ctx->is_indirect_mode
             && aot_intrinsic_check_capability(comp_ctx, "f32.const")) {
             WASMValue wasm_value;
@@ -80,7 +87,9 @@ aot_compile_op_f32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             }
             PUSH_F32(value);
         }
-        else {
+        else 
+#endif
+	{
             value = F32_CONST(f32_const);
             CHECK_LLVM_CONST(value);
             PUSH_F32(value);
@@ -124,6 +133,7 @@ aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMValueRef alloca, value;
 
     if (!isnan(f64_const)) {
+#if !defined(BUILD_TARGET_XTENSA)
         if (comp_ctx->is_indirect_mode
             && aot_intrinsic_check_capability(comp_ctx, "f64.const")) {
             WASMValue wasm_value;
@@ -135,7 +145,9 @@ aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             }
             PUSH_F64(value);
         }
-        else {
+        else 
+#endif
+	{
             value = F64_CONST(f64_const);
             CHECK_LLVM_CONST(value);
             PUSH_F64(value);

--- a/core/iwasm/compilation/aot_emit_conversion.c
+++ b/core/iwasm/compilation/aot_emit_conversion.c
@@ -347,7 +347,9 @@ aot_compile_op_i32_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F32(value);
 
+#if !defined(BUILD_TARGET_XTENSA)
     if (!comp_ctx->is_indirect_mode) {
+#endif
         if (sign) {
             min_value = F32_CONST(-2147483904.0f);
             max_value = F32_CONST(2147483648.0f);
@@ -356,6 +358,7 @@ aot_compile_op_i32_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             min_value = F32_CONST(-1.0f);
             max_value = F32_CONST(4294967296.0f);
         }
+#if !defined(BUILD_TARGET_XTENSA)
     }
     else {
         WASMValue wasm_value;
@@ -376,6 +379,7 @@ aot_compile_op_i32_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
         }
     }
+#endif
     CHECK_LLVM_CONST(min_value);
     CHECK_LLVM_CONST(max_value);
 
@@ -400,7 +404,9 @@ aot_compile_op_i32_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F64(value);
 
+#if !defined(BUILD_TARGET_XTENSA)
     if (!comp_ctx->is_indirect_mode) {
+#endif
         if (sign) {
             min_value = F64_CONST(-2147483649.0);
             max_value = F64_CONST(2147483648.0);
@@ -409,6 +415,7 @@ aot_compile_op_i32_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             min_value = F64_CONST(-1.0);
             max_value = F64_CONST(4294967296.0);
         }
+#if !defined(BUILD_TARGET_XTENSA)
     }
     else {
         WASMValue wasm_value;
@@ -429,6 +436,7 @@ aot_compile_op_i32_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
         }
     }
+#endif
     CHECK_LLVM_CONST(min_value);
     CHECK_LLVM_CONST(max_value);
 
@@ -554,7 +562,9 @@ aot_compile_op_i64_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F32(value);
 
+#if !defined(BUILD_TARGET_XTENSA)
     if (!comp_ctx->is_indirect_mode) {
+#endif
         if (sign) {
             min_value = F32_CONST(-9223373136366403584.0f);
             max_value = F32_CONST(9223372036854775808.0f);
@@ -563,6 +573,7 @@ aot_compile_op_i64_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             min_value = F32_CONST(-1.0f);
             max_value = F32_CONST(18446744073709551616.0f);
         }
+#if !defined(BUILD_TARGET_XTENSA)
     }
     else {
         WASMValue wasm_value;
@@ -583,6 +594,7 @@ aot_compile_op_i64_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
         }
     }
+#endif
     CHECK_LLVM_CONST(min_value);
     CHECK_LLVM_CONST(max_value);
 
@@ -607,7 +619,9 @@ aot_compile_op_i64_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F64(value);
 
+#if !defined(BUILD_TARGET_XTENSA)
     if (!comp_ctx->is_indirect_mode) {
+#endif
         if (sign) {
             min_value = F64_CONST(-9223372036854777856.0);
             max_value = F64_CONST(9223372036854775808.0);
@@ -616,6 +630,7 @@ aot_compile_op_i64_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             min_value = F64_CONST(-1.0);
             max_value = F64_CONST(18446744073709551616.0);
         }
+#if !defined(BUILD_TARGET_XTENSA)
     }
     else {
         WASMValue wasm_value;
@@ -636,6 +651,7 @@ aot_compile_op_i64_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
         }
     }
+#endif
     CHECK_LLVM_CONST(min_value);
     CHECK_LLVM_CONST(max_value);
 

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -134,6 +134,7 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     is_target_64bit = (comp_ctx->pointer_size == sizeof(uint64)) ? true : false;
 
+#if !defined(BUILD_TARGET_XTENSA)
     if (comp_ctx->is_indirect_mode
         && aot_intrinsic_check_capability(
             comp_ctx, MEMORY64_COND_VALUE("i64.const", "i32.const"))) {
@@ -154,7 +155,9 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             return NULL;
         }
     }
-    else {
+    else 
+#endif
+    {
         CHECK_LLVM_CONST(offset_const);
     }
 


### PR DESCRIPTION
Indirect-load for constants is not necessary on Xtensa, and will cause degraded performance. 
Direct-load for constants on Xtensa will not generate relocations now.